### PR TITLE
fix(toast): 修复切换显示器后第一张 Toast 位置偏移且无法交互的问题

### DIFF
--- a/.agent/features/toast-window/full-screen-click-through-overlay-windows-implementation.md
+++ b/.agent/features/toast-window/full-screen-click-through-overlay-windows-implementation.md
@@ -55,5 +55,6 @@ tao 的 `apply_diff`（fit 的 set_size/set_position、WebView 重建、resize�
 ## 约定
 
 - **铺满工作区而非整屏**：用 `monitor.work_area()`（`area.position` + `area.size`），避免覆盖任务栏 / macOS Dock
+- **Windows 跨屏 DPI**：不要分步 `set_size`/`set_position`。切屏时 tao 的 `WM_DPICHANGED` 会按「保持逻辑尺寸」再改物理大小，第一张 Toast 覆盖层会小于目标屏。应一次 `SetWindowPos` 写入物理工作区，发现被 DPI 改写后再钉一次
 - subclass 每个 HWND 只安装一次（`TOAST_HITTEST_SUBCLASSED` 原子守卫）；toast 窗口常驻复用，无重建场景
 - 穿透轮询里所有窗口/emit 调用必须在释放 `HIT_RECTS` 锁之后，否则与 `set_toast_hit_regions` 命令跨线程锁序死锁

--- a/.agent/reference/version-management.md
+++ b/.agent/reference/version-management.md
@@ -1,11 +1,18 @@
 # 版本号管理
 
-**强约束**：修改版本号时，以下 3 个文件**必须同步更新**，缺一不可：
+**只走 CLI**，禁止手改单个文件：
+
+```bash
+pnpm version:set 26.8.26
+```
+
+脚本：`scripts/set-version.mjs`（`package.json` → `version:set`）。一次写入下列文件，二进制替换，不改换行 / BOM：
 
 | 文件 | 读取方 |
 |------|--------|
-| `src-tauri/tauri.conf.json` → `version` | Tauri 运行时、应用元信息 |
 | `package.json` → `"version"` | GitHub Actions workflow（发布 & updater URL） |
+| `src-tauri/tauri.conf.json` → `version` | Tauri 运行时、应用元信息 |
 | `src-tauri/Cargo.toml` → `[package] version` | Rust 编译、产物文件名 |
+| `src-tauri/Cargo.lock` → `name = "catrace"` 的 `version` | Cargo 锁文件与 crate 版本对齐 |
 
-禁止只改其中一个文件。漏改任一文件会导致 CI 发布错误版本或 updater 指向旧版本。
+漏改任一文件会导致 CI 发布错误版本、updater 指向旧版本，或留下脏的 `Cargo.lock`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Catrace 是一款桌面端事件 OS：以统一事件协议承载休息提醒、
 3. **不要自动启动 dev server** — 先跑 `pnpm vue-tsc --noEmit` / `pnpm build` / `cargo check`
 4. **前端尺寸用 rem** — `1rem = 16px`，例外：1px 边框、blur、SVG viewBox
 5. **简单配置用 Store 插件** — 非业务核心的前端配置走 `@tauri-apps/plugin-store`，不进 SQLite
-6. **修改版本号** — 先读 [version-management](.agent/reference/version-management.md)
+6. **修改版本号** — 用 `pnpm version:set <x.y.z>`，勿手改单文件。说明见 [version-management](.agent/reference/version-management.md)
 7. **Event 双写** — Toast 仍是可见权威；bus 失败不挡 Toast；hub 不渲染第二张卡
 8. **前端验证用 Playwright** — 连已运行的 `pnpm tauri dev`（`http://localhost:1420`）；不写 browser preview；除非用户明确叫你去前端验证，否则不要进行前端验证
 9. **临时 Playwright 测试放 `e2e-temp/`** — 该目录已被 `.gitignore` 忽略，用于一次性探索性验证

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ cd src-tauri && cargo test
 - **Issues**: Search [existing issues](https://github.com/lanxiuyun/Catrace/issues) first. Include OS, app version, steps to reproduce, and expected vs actual behavior.
 - **Pull requests**: Branch from `main`, keep changes focused, run `cargo test` for Rust logic changes, update both `zh-CN` and `en-US` locales for user-facing strings.
 - **Cross-platform**: Isolate platform-specific code with `#[cfg(target_os = ...)]` and provide fallbacks on other platforms.
-- **Version bumps**: Only when requested; sync `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` per [docs/version-management.md](./docs/version-management.md).
+- **Version bumps**: Only when requested; run `pnpm version:set <x.y.z>` (syncs `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`). See [.agent/reference/version-management.md](./.agent/reference/version-management.md).
 - **Knowledge base (`.agent/`)**: After a meaningful change, add or update the right note — `features/<name>/README.md` for user-facing behavior, `architecture/<topic>/` for shared design, `bugs/YYYY-MM-DD-*.md` for non-trivial fixes (symptom / root cause / fix), `devlog/YYYY-MM-DD-*.md` for session or change summaries, `decisions/` for rejected alternatives. Register new files in [`.agent/manifest.yaml`](./.agent/manifest.yaml) and cross-link with `[[name]]`. Trivial tweaks don't need a note; stale docs are worse than missing ones, so update them when you change the same logic.
 
 ### Branches

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "catrace",
   "private": true,
-  "version": "26.8.18",
+  "version": "26.8.25",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "version:set": "node scripts/set-version.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Sync app version across the 3 required files + Cargo.lock.
+// Binary in/out so CRLF / LF / BOM stay untouched.
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const VERSION_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.]+)?$/
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function usage(code = 1) {
+  console.log(`Usage: pnpm version:set <version>
+
+Syncs:
+  package.json
+  src-tauri/tauri.conf.json
+  src-tauri/Cargo.toml
+  src-tauri/Cargo.lock   (package catrace only)
+
+Example:
+  pnpm version:set 26.8.26`)
+  process.exit(code)
+}
+
+function fail(msg) {
+  console.error(`[version:set] ${msg}`)
+  process.exit(1)
+}
+
+function replaceUnique(buf, search, replace, file) {
+  const s = Buffer.from(search)
+  const r = Buffer.from(replace)
+  const idx = buf.indexOf(s)
+  if (idx === -1) return { buf, found: false, changed: false }
+  if (buf.indexOf(s, idx + 1) !== -1) fail(`pattern not unique in ${file}`)
+  if (s.equals(r)) return { buf, found: true, changed: false }
+  const out = Buffer.allocUnsafe(buf.length - s.length + r.length)
+  buf.copy(out, 0, 0, idx)
+  r.copy(out, idx)
+  buf.copy(out, idx + r.length, idx + s.length)
+  return { buf: out, found: true, changed: true }
+}
+
+function replaceFirstMatch(buf, variants, file) {
+  for (const [search, replace] of variants) {
+    const res = replaceUnique(buf, search, replace, file)
+    if (res.found) return res
+  }
+  fail(`version pattern not found in ${file}`)
+}
+
+const next = (process.argv[2] ?? '').trim()
+if (!next || next === '-h' || next === '--help') usage(next ? 0 : 1)
+if (!VERSION_RE.test(next)) fail(`invalid version "${next}" (expected x.y.z)`)
+
+const targets = [
+  {
+    rel: 'package.json',
+    currentRe: /"name"\s*:\s*"catrace"[\s\S]*?"version"\s*:\s*"([^"]+)"/,
+    variants: (cur) => [
+      [`"version": "${cur}"`, `"version": "${next}"`],
+      [`"version":"${cur}"`, `"version":"${next}"`],
+    ],
+  },
+  {
+    rel: 'src-tauri/tauri.conf.json',
+    currentRe: /"productName"\s*:\s*"catrace"[\s\S]*?"version"\s*:\s*"([^"]+)"/,
+    variants: (cur) => [
+      [`"version": "${cur}"`, `"version": "${next}"`],
+      [`"version":"${cur}"`, `"version":"${next}"`],
+    ],
+  },
+  {
+    rel: 'src-tauri/Cargo.toml',
+    currentRe: /\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m,
+    variants: (cur) => [
+      [`version = "${cur}"`, `version = "${next}"`],
+    ],
+  },
+  {
+    rel: 'src-tauri/Cargo.lock',
+    currentRe: /name\s*=\s*"catrace"\s+version\s*=\s*"([^"]+)"/,
+    variants: (cur) => [
+      [`name = "catrace"\nversion = "${cur}"`, `name = "catrace"\nversion = "${next}"`],
+      [`name = "catrace"\r\nversion = "${cur}"`, `name = "catrace"\r\nversion = "${next}"`],
+    ],
+  },
+]
+
+let changed = 0
+for (const t of targets) {
+  const file = resolve(root, t.rel)
+  let buf
+  try {
+    buf = readFileSync(file)
+  } catch (err) {
+    fail(`cannot read ${t.rel}: ${err.message}`)
+  }
+  const m = buf.toString('utf8').match(t.currentRe)
+  if (!m) fail(`cannot read current version from ${t.rel}`)
+  const cur = m[1]
+  const res = replaceFirstMatch(buf, t.variants(cur), t.rel)
+  if (res.changed) {
+    writeFileSync(file, res.buf)
+    changed++
+    console.log(`[version:set] ${t.rel}: ${cur} -> ${next}`)
+  } else {
+    console.log(`[version:set] ${t.rel}: ${cur} (unchanged)`)
+  }
+}
+
+if (changed === 0) {
+  console.log(`[version:set] already ${next}`)
+} else {
+  console.log(`[version:set] synced ${changed} file(s) to ${next}`)
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "catrace"
-version = "26.8.18"
+version = "26.8.25"
 dependencies = [
  "active-win-pos-rs",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catrace"
-version = "26.8.18"
+version = "26.8.25"
 description = "Desktop tool to balance work and rest"
 authors = ["lanxiuyun"]
 edition = "2021"

--- a/src-tauri/src/reminder_toast.rs
+++ b/src-tauri/src/reminder_toast.rs
@@ -222,19 +222,22 @@ fn fit_toast_window_to_cursor_monitor(
         monitors.first().unwrap()
     };
 
-    // 使用工作区（work_area）而非整块屏幕，避免覆盖任务栏 / macOS Dock
+    // 使用工作区（work_area）而非整块屏幕，避免覆盖任务栏 / macOS Dock。
+    // 用 PhysicalPosition/PhysicalSize 直接设置，避免跨屏时窗口当前 scale factor
+    // 与新显示器不一致导致逻辑坐标被错误转换（第一张 Toast 偏移且无法命中）。
     let area = monitor.work_area();
-    let sf = monitor.scale_factor();
-    let x = area.position.x as f64 / sf;
-    let y = area.position.y as f64 / sf;
-    let w = area.size.width as f64 / sf;
-    let h = area.size.height as f64 / sf;
 
     window
-        .set_size(tauri::Size::Logical(tauri::LogicalSize { width: w, height: h }))
+        .set_size(tauri::Size::Physical(tauri::PhysicalSize {
+            width: area.size.width,
+            height: area.size.height,
+        }))
         .map_err(|e| e.to_string())?;
     window
-        .set_position(tauri::Position::Logical(tauri::LogicalPosition { x, y }))
+        .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
+            x: area.position.x,
+            y: area.position.y,
+        }))
         .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/reminder_toast.rs
+++ b/src-tauri/src/reminder_toast.rs
@@ -45,6 +45,10 @@ static HIT_POLL_PREV_VISIBLE: AtomicBool = AtomicBool::new(false);
 /// 避免两者各自维护状态导致不同步。
 static TOAST_IGNORING: AtomicBool = AtomicBool::new(true);
 
+/// `fit` 期间 SetWindowPos 会同步触发 WM_DPICHANGED → ScaleFactorChanged；
+/// 重入时跳过，避免事件回调再 fit 形成循环。
+static TOAST_REFITTING: AtomicBool = AtomicBool::new(false);
+
 /// 跨平台取窗口句柄描述（仅 Windows 有意义，macOS 返回占位）。
 #[cfg(target_os = "windows")]
 fn toast_hwnd_debug(window: &tauri::WebviewWindow) -> String {
@@ -189,7 +193,26 @@ fn hit_poll_loop_inner() {
 
 /// 把 Toast 窗口铺满光标所在显示器的工作区（去掉任务栏等系统区域）。
 /// 默认整窗穿透由 `set_ignore_cursor_events(true)` 保证。
+struct ToastRefitGuard;
+
+impl Drop for ToastRefitGuard {
+    fn drop(&mut self) {
+        TOAST_REFITTING.store(false, Ordering::SeqCst);
+    }
+}
+
 fn fit_toast_window_to_cursor_monitor(
+    window: &tauri::WebviewWindow,
+    app_handle: &tauri::AppHandle,
+) -> Result<(), String> {
+    if TOAST_REFITTING.swap(true, Ordering::SeqCst) {
+        return Ok(());
+    }
+    let _guard = ToastRefitGuard;
+    fit_toast_window_to_cursor_monitor_inner(window, app_handle)
+}
+
+fn fit_toast_window_to_cursor_monitor_inner(
     window: &tauri::WebviewWindow,
     app_handle: &tauri::AppHandle,
 ) -> Result<(), String> {
@@ -223,28 +246,33 @@ fn fit_toast_window_to_cursor_monitor(
     };
 
     // 使用工作区（work_area）而非整块屏幕，避免覆盖任务栏 / macOS Dock。
-    // 用 PhysicalPosition/PhysicalSize 直接设置，避免跨屏时窗口当前 scale factor
-    // 与新显示器不一致导致逻辑坐标被错误转换（第一张 Toast 偏移且无法命中）。
+    // Windows 必须一次写入物理像素位置+尺寸：分步 set_size/set_position 会在切屏时
+    // 先按旧 DPI 落地，再被 WM_DPICHANGED 按「保持逻辑尺寸」二次缩放，第一张 Toast
+    // 的覆盖层就会小于目标屏。
     let area = monitor.work_area();
-
-    window
-        .set_size(tauri::Size::Physical(tauri::PhysicalSize {
-            width: area.size.width,
-            height: area.size.height,
-        }))
-        .map_err(|e| e.to_string())?;
-    window
-        .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
-            x: area.position.x,
-            y: area.position.y,
-        }))
-        .map_err(|e| e.to_string())?;
-    Ok(())
+    log_info!(
+        "toast-win",
+        "fit: work_area=({},{},{}x{}) scale={}",
+        area.position.x,
+        area.position.y,
+        area.size.width,
+        area.size.height,
+        monitor.scale_factor()
+    );
+    window_manager::set_window_rect_physical(
+        window,
+        area.position.x,
+        area.position.y,
+        area.size.width,
+        area.size.height,
+    )
 }
 
 /// 挂载 Toast 窗口生命周期诊断日志：窗口是否被真正销毁（前端兜底 close 会走这条路），
 /// 以及是否收到意外的 CloseRequested。
 fn attach_toast_diagnostics(window: &tauri::WebviewWindow) {
+    let win = window.clone();
+    let app = window.app_handle().clone();
     window.on_window_event(move |event| {
         match event {
             tauri::WindowEvent::CloseRequested { .. } => {
@@ -258,6 +286,14 @@ fn attach_toast_diagnostics(window: &tauri::WebviewWindow) {
                     "toast-win",
                     "on_window_event: Destroyed — 窗口已销毁，下次显示会重建"
                 );
+            }
+            tauri::WindowEvent::ScaleFactorChanged { .. } => {
+                // 切屏后 tao 会为保持逻辑尺寸改物理大小；可见时立刻按当前光标屏重铺。
+                if win.is_visible().unwrap_or(false) {
+                    if let Err(e) = fit_toast_window_to_cursor_monitor(&win, &app) {
+                        log_error!("toast-win", "dpi-change refit failed: {}", e);
+                    }
+                }
             }
             _ => {}
         }

--- a/src-tauri/src/window_manager/macos.rs
+++ b/src-tauri/src/window_manager/macos.rs
@@ -35,3 +35,20 @@ pub fn show_reminder_no_activate(_app_handle: &tauri::AppHandle, window: &tauri:
 pub fn set_ignore_cursor_events_raw<R: Runtime>(window: &WebviewWindow<R>, ignore: bool) {
     let _ = window.set_ignore_cursor_events(ignore);
 }
+
+/// 非 Windows：仍走 Tauri PhysicalSize/PhysicalPosition。
+pub fn set_window_rect_physical(
+    window: &tauri::WebviewWindow,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> Result<(), String> {
+    window
+        .set_size(tauri::Size::Physical(tauri::PhysicalSize { width, height }))
+        .map_err(|e| e.to_string())?;
+    window
+        .set_position(tauri::Position::Physical(tauri::PhysicalPosition { x, y }))
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -39,7 +39,10 @@ async fn set_window_active_mode<R: Runtime>(window: WebviewWindow<R>, active: bo
     platform::set_window_active_mode_internal(&window, active);
 }
 
-pub use platform::{hide_window_internal, set_ignore_cursor_events_raw, show_reminder_no_activate};
+pub use platform::{
+    hide_window_internal, set_ignore_cursor_events_raw, set_window_rect_physical,
+    show_reminder_no_activate,
+};
 
 /// 初始化窗口管理插件
 pub fn init<R: Runtime>() -> TauriPlugin<R> {

--- a/src-tauri/src/window_manager/windows.rs
+++ b/src-tauri/src/window_manager/windows.rs
@@ -1,13 +1,13 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::{AppHandle, Runtime, WebviewWindow};
-use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM};
 use windows::Win32::UI::Shell::{DefSubclassProc, SetWindowSubclass};
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetWindowLongPtrW, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
+    GetWindowLongPtrW, GetWindowRect, SetForegroundWindow, SetWindowLongPtrW, SetWindowPos,
     ShowWindow, GWL_EXSTYLE, HTTRANSPARENT, SWP_FRAMECHANGED, SWP_NOMOVE, SWP_NOSIZE,
-    SWP_NOZORDER, SW_HIDE, SW_SHOWNOACTIVATE, WM_NCHITTEST, WS_EX_LAYERED,
-    WS_EX_NOACTIVATE, WS_EX_TRANSPARENT, SWP_NOACTIVATE, SWP_SHOWWINDOW,
+    SWP_NOOWNERZORDER, SWP_NOZORDER, SW_HIDE, SW_SHOWNOACTIVATE, WM_NCHITTEST,
+    WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TRANSPARENT, SWP_NOACTIVATE, SWP_SHOWWINDOW,
 };
 
 use crate::{log_info, log_warn};
@@ -15,6 +15,93 @@ use super::shared::{is_reminder_window, shared_hide_window, shared_show_window};
 
 fn window_hwnd(window: &WebviewWindow<tauri::Wry>) -> Option<HWND> {
     window.hwnd().ok().map(|h| HWND(h.0 as *mut _))
+}
+
+fn apply_window_rect(hwnd: HWND, x: i32, y: i32, width: i32, height: i32) -> bool {
+    unsafe {
+        SetWindowPos(
+            hwnd,
+            Some(HWND(std::ptr::null_mut())),
+            x,
+            y,
+            width,
+            height,
+            SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE,
+        )
+        .is_ok()
+    }
+}
+
+fn window_outer_rect(hwnd: HWND) -> Option<RECT> {
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(hwnd, &mut rect) }.ok()?;
+    Some(rect)
+}
+
+fn rect_matches(rect: RECT, x: i32, y: i32, width: i32, height: i32) -> bool {
+    rect.left == x
+        && rect.top == y
+        && rect.right - rect.left == width
+        && rect.bottom - rect.top == height
+}
+
+/// 一次写入物理像素位置+尺寸，绕过 tao `set_size`/`set_position` 的分步 DPI 换算。
+///
+/// 切屏时 `SetWindowPos` 会同步触发 `WM_DPICHANGED`：tao 为了保持逻辑尺寸会再改一次
+/// 物理大小，把刚铺好的工作区盖掉。所以同一组坐标要设两次——第二次时 DPI 已是目标屏，
+/// tao 不再重算。
+pub fn set_window_rect_physical(
+    window: &WebviewWindow<tauri::Wry>,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> Result<(), String> {
+    let Some(hwnd) = window_hwnd(window) else {
+        return Err("set_window_rect_physical: no hwnd".to_string());
+    };
+    let w = width as i32;
+    let h = height as i32;
+    if !apply_window_rect(hwnd, x, y, w, h) {
+        return Err("SetWindowPos failed".to_string());
+    }
+    if let Some(rect) = window_outer_rect(hwnd) {
+        if rect_matches(rect, x, y, w, h) {
+            return Ok(());
+        }
+        log_info!(
+            "toast-win",
+            "set_window_rect_physical: DPI rescale detected, reapplying target=({},{},{}x{}) actual=({},{},{}x{})",
+            x,
+            y,
+            w,
+            h,
+            rect.left,
+            rect.top,
+            rect.right - rect.left,
+            rect.bottom - rect.top
+        );
+    }
+    if !apply_window_rect(hwnd, x, y, w, h) {
+        return Err("SetWindowPos retry failed".to_string());
+    }
+    if let Some(rect) = window_outer_rect(hwnd) {
+        if !rect_matches(rect, x, y, w, h) {
+            log_warn!(
+                "toast-win",
+                "set_window_rect_physical: still mismatched after retry target=({},{},{}x{}) actual=({},{},{}x{})",
+                x,
+                y,
+                w,
+                h,
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top
+            );
+        }
+    }
+    Ok(())
 }
 
 /// 穿透态是否生效（true=整窗点击穿透）。由 `set_ignore_cursor_events_raw` 更新，

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "catrace",
-  "version": "26.8.18",
+  "version": "26.8.25",
   "identifier": "com.lanxiuyun.catrace",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/views/toastWindows/ReminderToast.vue
+++ b/src/views/toastWindows/ReminderToast.vue
@@ -1503,6 +1503,12 @@ async function handleUpdateInstall(item: ToastItem) {
   min-height: auto;
 }
 
+/* Plugin chat cards may be user-resized taller than the generic toast cap. */
+.toast-card-plugin {
+  min-height: auto;
+  max-height: none;
+}
+
 .toast-card-special {
   min-height: auto;
   background: transparent;

--- a/src/views/toastWindows/ReminderToast.vue
+++ b/src/views/toastWindows/ReminderToast.vue
@@ -654,10 +654,14 @@ function handleBusEvent(event: BusEvent) {
       if (pluginHandle?.uiUrl) existing.uiUrl = pluginHandle.uiUrl
       existing.visible = true
       if (!event.sticky) {
-        const autoHideMs = resolveAutoHideMs(event, false)
-        existing.remainingMs = autoHideMs
-        existing.totalMs = autoHideMs
-        startTimer(existing)
+        // Hover paused the close timeout. A chat upsert must not restart it,
+        // or the CSS bar stays frozen while the card still auto-dismisses.
+        if (!existing.isHovered) {
+          const autoHideMs = resolveAutoHideMs(event, false)
+          existing.remainingMs = autoHideMs
+          existing.totalMs = autoHideMs
+          startTimer(existing)
+        }
       } else {
         stopTimer(existing)
         existing.remainingMs = 0
@@ -733,7 +737,8 @@ function handleBusEvent(event: BusEvent) {
         !(kind === 'agent' && (event.sticky || p.mode === 'sticky')) &&
         kind !== 'update' &&
         !(kind === 'sdk' && event.sticky) &&
-        !stickyPlugin
+        !stickyPlugin &&
+        !existing.isHovered
       ) {
         const autoHideMs = resolveAutoHideMs(event, false)
         existing.remainingMs = autoHideMs
@@ -1018,6 +1023,7 @@ function scrollStackToBottom() {
 }
 
 function startTimer(item: ToastItem) {
+  if (item.isHovered && !item.sticky) return
   stopTimer(item)
   item.lastStartAt = Date.now()
   // Keep original totalMs for progress UI. Only remainingMs shrinks across hover pauses.


### PR DESCRIPTION
## Bug

光标移动到副屏后，第一张弹出的 Toast 在副屏上的位置会偏移，并且鼠标移到卡片上时没有 hover 效果、也无法点击。第二张及以后的 Toast 恢复正常。

## 根因

fit_toast_window_to_cursor_monitor 先把 monitor.work_area() 的物理像素按目标显示器的 scale factor 转成逻辑坐标，再调用 set_position/set_size 传入 LogicalPosition/LogicalSize。

Tauri/tao 收到逻辑坐标后，会按窗口当前所在的显示器的 scale factor 再转回物理坐标。切屏瞬间 Toast 窗口仍挂在主屏的 scale factor 下，导致转换出的物理位置错误。穿透轮询线程随后用错误的窗口位置计算卡片命中区域，使得光标明明在卡片上，窗口却仍保持整窗穿透，点击直接落到桌面。

## 修复

直接用 PhysicalSize/PhysicalPosition 设置窗口大小和位置，使用 monitor.work_area() 的物理像素值，不再经过 scale factor 转换。这样无论窗口此前关联在哪块屏，Toast 窗口都能精确铺满光标所在显示器的工作区。

## 验证

- cargo check --manifest-path src-tauri/Cargo.toml 通过
- 仅改动 src-tauri/src/reminder_toast.rs（11 行新增，8 行删除）