### PR TITLE
fix(plugins): enable/disable 改为 diff 式 sidecar 同步,不再误杀其他插件的进程树

### DIFF
--- a/.agent/architecture/desktop-event-os/plugin-native-sidecar-runtime.md
+++ b/.agent/architecture/desktop-event-os/plugin-native-sidecar-runtime.md
@@ -89,9 +89,12 @@ Without `sidecar`, behavior is unchanged. Manifest scanning only parses structur
 | `lib.rs` | `PluginSidecarManager` state；与 window 同一 schedule 点 | ✅ |
 | Plugins UI / anomaly | sidecar 运行态展示 | ✅ M15.3 |
 
-启停触发与 M11 对齐：
+启停触发：
 
-- `initial_scan` / rescan / set_enabled / 退出  
+- enable → `sync_plugin(id)` 只启动这一颗；disable → 只停这一颗  
+- 插件页刷新 → `schedule_sync_force`（按 enable/disable 全量重启）  
+- 被动 list/rescan → `schedule_sync`：补齐未启动、停已禁用、换已崩溃；**不**因指纹弹健康进程  
+- 退出仍杀进程树  
 - **禁止**在 `setup()` 同步长阻塞；`spawn_blocking` + 锁，同 `PluginWindowManager::schedule_sync`
 - **扫描期不做**路径穿越 / 解释器 allowlist / env 安全校验（产品决策）；spawn 失败当运行时错误
 
@@ -154,7 +157,7 @@ starting ──spawn fail──► error (UI 可见，可重试)
    │ ready 或首条合法 op
    ▼
 running ──crash──► backoff restart（有限次数）──► error
-   │ disable / app exit / fingerprint change
+   │ disable / app exit / 插件页刷新(force) / 关开自己
    ▼
 stopping → (shutdown 宽限 e.g. 1s) → kill → disabled
 ```

--- a/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
+++ b/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
@@ -1,0 +1,33 @@
+# 2026-08-31 sidecar 重启误杀其他插件的子进程树
+
+## 症状
+
+bt-music 插件 sidecar 拉起的播放器进程（cloudmusic.exe）会在**任意其他外部插件被打开/关闭时一起退出**（无声消失，无报错）。久坐提醒是内置插件、无外部进程，不受影响。
+
+## 根因
+
+- commit `96da4e1` 为解决「改 runtime 脚本后点刷新仍跑旧代码」，把 enable/disable 的 sidecar 同步改为 `sync_force`——每次开关**任意**外部插件都会重启**全部**已启用 sidecar（`src-tauri/src/plugin_sidecar.rs` `sync_impl` 中 `force → restart = true`）。
+- 停 sidecar 走 `stop_sidecar`：发 `shutdown` 后宽限 500ms，超时 `taskkill /PID /T /F` 杀整棵进程树；且 `RunningSidecar` 析构必关 Job Object 句柄，`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` 兜底杀树。cloudmusic.exe 是 sidecar 的孙进程（node → PowerShell Start-Process → exe），随树被杀。
+- 深层原因：`sidecar_fingerprint` 只含 `version:command:args:cwd:env`，**不含 entry 文件 mtime/hash**，偏离 ADR「sidecar-runtime #6：文件变化→重启该 sidecar」；force 全量重启是绕过该缺陷的补丁，副作用就是误杀。
+
+## 修复（宿主内做）
+
+在 `src-tauri/src/plugins.rs`：
+
+- `sidecar_fingerprint` 追加 entry 脚本文件统计 `len:mtime_ms`（取 args 中相对路径且存在的文件；`-` 前缀 flag、绝对路径、含 `..` 的参数安全过滤）——与 `background_fingerprint` 同款算法。
+- `set_external_plugin_enabled` 的 `sync_force` 改回 `sync`（diff 式）：只启停被开关的插件，其他 sidecar 不重启。
+- 刷新按钮的 `schedule_sync_force` 保留（显式 reload 语义不变）。
+- 删除因此失去调用的 `PluginSidecarManager::sync_force`（同步变体）。
+
+## 行为变化（对齐 ADR）
+
+改插件 X 的脚本后，开关插件 Y **不再顺带刷新 X**；X 的改动在 X 自己开关或点「刷新」时生效（指纹已能检测脚本文件变化）。
+
+## 涉及文件
+
+- `src-tauri/src/plugins.rs` — `sidecar_fingerprint` 补 entry 文件统计、`set_external_plugin_enabled` 改 diff 同步、单测 `sidecar_fingerprint_tracks_entry_file_changes`
+- `src-tauri/src/plugin_sidecar.rs` — 删除 `sync_force`
+
+## 验证
+
+`cargo check --all-targets` 零警告；`cargo test` 66 通过（含新指纹单测）。运行时验证（Windows 11，用户执行）：开关其他外部插件 → cloudmusic.exe 存活；关/开 bt-music 自身 → 播放器随关随开；改脚本后点「刷新」→ 全量重启。「改脚本后开关生效」机制由指纹单测覆盖，未单独实测。

--- a/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
+++ b/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
@@ -31,4 +31,4 @@ bt-music 插件 sidecar 拉起的播放器进程（cloudmusic.exe）会在**任�
 
 ## 验证
 
-`cargo check --all-targets` 零警告；`cargo test` 66 通过（含新指纹单测）。运行时验证（Windows 11，用户执行）：开关其他外部插件 → cloudmusic.exe 存活；关/开 bt-music 自身 → 播放器随关随开；改脚本后点「刷新」→ 全量重启。「改脚本后开关生效」机制由指纹单测覆盖，未单独实测。
+`cargo check --all-targets` 零警告。运行时预期：开关其他外部插件 → cloudmusic.exe 存活；关/开 bt-music 自身 → 播放器随关随开；改脚本后关开该插件 → 只换这一颗；点「刷新」→ 全量重启。指纹不驱动重启。

--- a/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
+++ b/.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
@@ -15,18 +15,19 @@ bt-music 插件 sidecar 拉起的播放器进程（cloudmusic.exe）会在**任�
 在 `src-tauri/src/plugins.rs`：
 
 - `sidecar_fingerprint` 追加 entry 脚本文件统计 `len:mtime_ms`（取 args 中相对路径且存在的文件；`-` 前缀 flag、绝对路径、含 `..` 的参数安全过滤）——与 `background_fingerprint` 同款算法。
-- `set_external_plugin_enabled` 的 `sync_force` 改回 `sync`（diff 式）：只启停被开关的插件，其他 sidecar 不重启。
-- 刷新按钮的 `schedule_sync_force` 保留（显式 reload 语义不变）。
-- 删除因此失去调用的 `PluginSidecarManager::sync_force`（同步变体）。
+- `set_external_plugin_enabled` 改为 `sync_plugin`：enable 只启动这一颗，disable 只停这一颗。已在跑且没崩的不重启。
+- 插件页「刷新」走 `schedule_sync_force`：按当前 enable/disable 全量重启。改脚本后要点这个按钮才换新进程。
+- 删除因此失去调用的 `PluginSidecarManager::sync_force` / `sync`。
 
-## 行为变化（对齐 ADR）
+## 行为（就两件事）
 
-改插件 X 的脚本后，开关插件 Y **不再顺带刷新 X**；X 的改动在 X 自己开关或点「刷新」时生效（指纹已能检测脚本文件变化）。
+- **开关**：enable → 启该 sidecar；disable → 停该 sidecar。不碰其他插件。
+- **刷新按钮**：按 enable/disable 把所有 sidecar 重新走一遍（enabled 重启，disabled 停掉）。
 
 ## 涉及文件
 
-- `src-tauri/src/plugins.rs` — `sidecar_fingerprint` 补 entry 文件统计、`set_external_plugin_enabled` 改 diff 同步、单测 `sidecar_fingerprint_tracks_entry_file_changes`
-- `src-tauri/src/plugin_sidecar.rs` — 删除 `sync_force`
+- `src-tauri/src/plugins.rs` — `sidecar_fingerprint` 补 entry 文件统计、`set_external_plugin_enabled` 走 `sync_plugin`、单测 `sidecar_fingerprint_tracks_entry_file_changes`
+- `src-tauri/src/plugin_sidecar.rs` — 删除 `sync_force`，新增 `sync_plugin`（只动一颗）
 
 ## 验证
 

--- a/.agent/decisions/2026-07-30-plugin-native-sidecar-runtime.md
+++ b/.agent/decisions/2026-07-30-plugin-native-sidecar-runtime.md
@@ -76,7 +76,7 @@ manifest 可选字段 `sidecar`（名可微调，实现时以架构文为准）�
 3. Manifest scanning parses structure only. A command that cannot start is reported as a runtime error and does not prevent listing the plugin.
 4. Host identity variables such as `CATRACE_PLUGIN_ID` and the protocol version are injected last and override manifest values.
 5. **不**内置 Node/Python 运行时二进制（保持 2026-07-23「不 +40MB」）；要 Node 生态 = 用户机器有 Node，或插件自带 exe。
-6. fingerprint：manifest + entry 文件 mtime/hash 变 → 重启 sidecar（与 background 窗重建对齐）。
+6. fingerprint：仍计算（含 entry 文件统计），**不**作为自动重启条件。要新进程：关开该插件（只动一颗）或点刷新（全量）。见 [2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md](2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md)。
 
 ### 4. Bridge 协议（sidecar ↔ 宿主）
 

--- a/.agent/decisions/2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md
+++ b/.agent/decisions/2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md
@@ -1,0 +1,32 @@
+# 2026-09-01 sidecar 启停只跟开关和刷新按钮走，不用指纹扫全表
+
+## 背景
+
+ADR [plugin-native-sidecar-runtime](2026-07-30-plugin-native-sidecar-runtime.md) §4 规则 6 写过：fingerprint（manifest + entry mtime/hash）变 → 重启该 sidecar。
+
+`96da4e1` 为了「改 runtime 脚本后点刷新仍跑旧代码」，把 enable/disable 做成 `sync_force`：开关**任意**外部插件都会重启**全部**已启用 sidecar。停进程杀整棵树（`taskkill /T` + Job Object），bt-music 拉起的播放器会一起没。见 [sidecar重启误杀其他插件的子进程树.md](../bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md)。
+
+原 PR 把 toggle 改回全表 `sync()`，并给指纹补上 entry 文件统计。这能避免「无条件 force」，但只要 X 的指纹变了，开关 Y 仍会重启 X。
+
+## 决定
+
+产品语义压成用户能看见的两控件，外加「关开自己」：
+
+- **开关：** `sync_plugin(id)`。enable 启、disable 停。已在跑且没崩 → 不重启。别人一律不动。
+- **刷新：** `schedule_sync_force`。按当前 enable/disable 全量重启。
+- **只要换 X 的进程、不要动别人：** 关开 X（停旧再按磁盘 spawn）。
+
+指纹仍计算（含 entry `len:mtime_ms`）并保留单测，但**不是**启停决策输入。被动 `schedule_sync`（进页、toast list）只补齐/停禁用/换崩溃，不因文件 mtime 弹健康进程。
+
+## 为什么不跟 ADR #6 做自动重启
+
+- 没有文件监视，所谓「文件变了」只能在某次 sync 时看到。把指纹接进全表 sync，等于「开关别人 / 拉一次列表」也能杀掉指纹变了的插件，包括它的孙进程。
+- 指纹只覆盖 sidecar `args` 里相对存在的文件（现有插件几乎是 `runtime/main.mjs`）。改 import 进去的别的脚本不会变指纹，自动重启本来就不完整；完整换代码仍靠刷新或关开该插件。
+- 用户心智：开就是开、关就是关；reload 才全员按开关重来。比「隐式指纹」清晰。
+
+规则 6 收窄为：文件变化**不**自动重启；要新进程走刷新（全量）或关开该插件（单颗）。
+
+## 后果
+
+- 改脚本后若既不关开该插件、也不点刷新，旧进程继续跑。这是刻意的。
+- 点刷新会重启所有已启用 sidecar（含 bt-music 播放器）。这是刷新按钮的语义，不是 bug。

--- a/.agent/devlog/2026-09-01-sidecar开关不再全量重启以免误杀其他插件进程树.md
+++ b/.agent/devlog/2026-09-01-sidecar开关不再全量重启以免误杀其他插件进程树.md
@@ -1,0 +1,25 @@
+# 2026-09-01 sidecar 开关不再全量重启，以免误杀其他插件进程树
+
+## 会话目标
+
+PR #60：开关外部插件时不要 `sync_force` 全杀已启用 sidecar（bt-music 播放器被误杀）。对齐产品：开/关只动当前插件；刷新才按 enable/disable 全量重启。
+
+## 完成项
+
+- `set_external_plugin_enabled` 走 `sync_plugin(id)`，不再全表 `sync` / `sync_force`
+- 非 force `schedule_sync`：只补启动、停禁用、换崩溃；不用指纹弹健康进程
+- 刷新按钮仍 `schedule_sync_force`
+- 关开某一颗 = 只重启那一颗（改脚本要只换 X 用这条）
+
+## 待开发
+
+- PR 在 fork 上，CI 需仓库主 Approve and run workflows
+- 指纹自动重启（ADR 旧 #6）明确不做；若以后要「存盘只重启 X」，需要单独设计（监视或显式「重载此插件」），不能接回全表 sync
+
+## 关键文件变更
+
+| 文件 | 变更 |
+|------|------|
+| `src-tauri/src/plugin_sidecar.rs` | `sync_plugin`；force 才全量重启 |
+| `src-tauri/src/plugins.rs` | toggle 调 `sync_plugin`；list 的 `restartSidecars` 才 force |
+| `.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md` | 现象与现行语义 |

--- a/.agent/features/plugin-center/README.md
+++ b/.agent/features/plugin-center/README.md
@@ -13,7 +13,8 @@
 - `tools/plugin-demo/timer/settings.mjs` — 外部 settings 参考（内联编辑、边距归宿主）。
 - `src/plugins/pluginRuntime.ts` — 外部插件 Vue/naive/UI runtime 注入。
 - `src/api/tauri.ts` — 插件启用与外部异常状态。
-- `src-tauri/src/plugin_commands.rs` / `plugins.rs` — 外部插件与异常观测。
+- `src-tauri/src/plugin_commands.rs` / `plugins.rs` — 外部插件与异常观测；enable 走 `sync_plugin`。
+- `src-tauri/src/plugin_sidecar.rs` — sidecar 启停；开关只动一颗，刷新才 `schedule_sync_force`。
 
 ## Sub-documents
 
@@ -21,6 +22,7 @@
 - [插件状态排序和统一详情顶栏实现约定.md](插件状态排序和统一详情顶栏实现约定.md) — 状态来源、排序、顶栏边界。
 - [插件中心-sidecar本机进程徽章与信任文案展示.md](插件中心-sidecar本机进程徽章与信任文案展示.md) — hasSidecar / sidecarRunning badge 与 trustNote。
 - [插件异常标签如何判定和保持不拦截.md](插件异常标签如何判定和保持不拦截.md) — 异常 Tag 与观测。
+- [插件开关只启停当前sidecar-刷新按钮才按enable全量重启.md](插件开关只启停当前sidecar-刷新按钮才按enable全量重启.md) — 外部 sidecar 生命周期：开关 / 关开自己 / 刷新全量。
 - [插件开关必须在持久化成功后再刷新列表.md](插件开关必须在持久化成功后再刷新列表.md) — 开关与列表时序。
 - [插件面板和导航栏组件化拆分.md](插件面板和导航栏组件化拆分.md) — header / nav-rail 拆分。
 - [unify-plugin-panel-shell-and-section-for-agent-rest-panels.md](unify-plugin-panel-shell-and-section-for-agent-rest-panels.md) — 历史：PluginPanelShell 已废弃。

--- a/.agent/features/plugin-center/插件中心-sidecar本机进程徽章与信任文案展示.md
+++ b/.agent/features/plugin-center/插件中心-sidecar本机进程徽章与信任文案展示.md
@@ -32,7 +32,7 @@ list_external_plugins / set_external_plugin_enabled
   → PluginNavRail / PluginPanelHeader
 ```
 
-- `set_external_plugin_enabled` 在 Rust 侧先 `sidecars.sync` 再填 `sidecar_running`，前端不必再等一轮 refresh 才能看到绿点。
+- `set_external_plugin_enabled` 在 Rust 侧先 `sidecars.sync_plugin(id)` 再填 `sidecar_running`，前端不必再等一轮 refresh 才能看到绿点。只启停当前插件，不会重启别的 sidecar。
 
 ## i18n keys
 

--- a/.agent/features/plugin-center/插件开关只启停当前sidecar-刷新按钮才按enable全量重启.md
+++ b/.agent/features/plugin-center/插件开关只启停当前sidecar-刷新按钮才按enable全量重启.md
@@ -1,0 +1,33 @@
+# 插件开关只启停当前 sidecar，刷新按钮才按 enable 全量重启
+
+外部插件的本机进程（sidecar）生命周期只跟两件事走，不要用「改了文件 / 开关了别人」去扫全表。
+
+## 三句话
+
+1. **开 = 只启动这一颗；关 = 只停这一颗。** 不碰其他插件的进程树（含 sidecar 拉起的孙进程，如 bt-music 的播放器）。
+2. **改了 X 的脚本要只换 X：** 把 X 关掉再打开。关开 = 停旧进程、按磁盘再 spawn，别人不动。
+3. **插件页刷新按钮：** 按当前 enable/disable 全量走一遍（enabled 全部重启，disabled 停掉）。这是唯一的「全员 reload」。
+
+没有文件监视。存盘不会自动重启。指纹（entry `len:mtime_ms`）会算、有单测，**不作为重启条件**。
+
+## 对应代码
+
+| 用户动作 | 命令 / API | sidecar 行为 |
+|---|---|---|
+| 顶栏开关 | `set_external_plugin_enabled` → `sync_plugin(id)` | 只启停 `id`；已在跑且没崩的不重启 |
+| 导航栏刷新 | `list_external_plugins(restartSidecars=true)` → `schedule_sync_force` | 全量：enabled 重启，disabled 停 |
+| 进页 / toast 拉列表 | `list_external_plugins` 默认 → `schedule_sync` | 只补没起来的、停已禁用的、换已崩溃的；健康进程不弹 |
+
+停进程走 `stop_sidecar`：`shutdown` 宽限后 `taskkill /T /F`，Windows 上 Job Object `KILL_ON_JOB_CLOSE` 兜底。所以**绝不能**把「开关别人」做成 force 全量。
+
+## 不要做
+
+- 不要在 enable/disable 里调 `sync_force` / 全表 `sync()`。那是 `96da4e1` 的回归：任意开关都会杀掉 bt-music 的 `cloudmusic.exe`。
+- 不要靠指纹 mismatch 在「开关 Y」时顺带重启 X。要换 X 的代码：关开 X，或点刷新（全量）。
+- 不要把刷新按钮理解成「只热更新 UI」。它会重启所有已启用 sidecar。
+
+## 相关
+
+- 误杀案例：[.agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md](../../bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md)
+- 决策：[.agent/decisions/2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md](../../decisions/2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md)
+- 架构：[[desktop-event-os]] [plugin-native-sidecar-runtime.md](../../architecture/desktop-event-os/plugin-native-sidecar-runtime.md)

--- a/.agent/manifest.yaml
+++ b/.agent/manifest.yaml
@@ -6,6 +6,7 @@ features:
       - .agent/features/plugin-center/unify-plugin-panel-shell-and-section-for-agent-rest-panels.md
       - .agent/features/plugin-center/插件状态排序和统一详情顶栏实现约定.md
       - .agent/features/plugin-center/插件中心-sidecar本机进程徽章与信任文案展示.md
+      - .agent/features/plugin-center/插件开关只启停当前sidecar-刷新按钮才按enable全量重启.md
       - .agent/features/plugin-center/插件异常标签如何判定和保持不拦截.md
       - .agent/features/plugin-center/插件开关必须在持久化成功后再刷新列表.md
       - .agent/features/plugin-center/插件面板和导航栏组件化拆分.md
@@ -266,6 +267,7 @@ reference:
   - .agent/reference/windows-PowerShell控制台GBK码页导致UTF8字节误判.md
 
 decisions:
+  - .agent/decisions/2026-09-01-sidecar启停只跟开关和刷新按钮走-不用指纹扫全表.md
   - .agent/decisions/2026-08-31-更新允许换GitHub镜像源-检查与下载同一源.md
   - .agent/decisions/2026-08-31-插件提示音走宿主audio-不走shell-beep.md
   - .agent/decisions/2026-08-11-插件抽离到catrace-plugin仓库并以submodule挂在tools-plugin-demo.md
@@ -333,6 +335,7 @@ skills:
       - event-sdk
 
 devlog:
+  - .agent/devlog/2026-09-01-sidecar开关不再全量重启以免误杀其他插件进程树.md
   - .agent/devlog/2026-08-31-更新支持换源Toast也能选.md
   - .agent/devlog/2026-08-31-定时提醒颜色提示音与plugin-audio-API.md
   - .agent/devlog/2026-08-27-toast小窗化与点击抢焦点修复.md
@@ -358,7 +361,7 @@ devlog:
   - .agent/devlog/2026-07-25-主窗与Toast窗views拆分与nested-route外壳.md
   - .agent/devlog/2026-07-25-插件面板header与左侧导航栏组件化拆分.md
 
-  current:
-    plan: .agent/architecture/desktop-event-os/README.md
-    phase: 更新支持换 GitHub 镜像源（设置页 + Toast）（2026-08-31）
-    next: 用户确认后可测换源检查/下载；此前 plugin.audio 仍待用户 push
+current:
+  plan: .agent/architecture/desktop-event-os/README.md
+  phase: sidecar 开关只启停当前插件，刷新才全量重启（2026-09-01，pr/60）
+  next: 用户确认后 push / 合 PR #60；fork CI 需 Approve and run workflows

--- a/.agent/manifest.yaml
+++ b/.agent/manifest.yaml
@@ -287,6 +287,7 @@ decisions:
   - .agent/decisions/window-focus-refactor.md
 
 bugs:
+  - .agent/bugs/2026-08-31-sidecar重启误杀其他插件的子进程树.md
   - .agent/bugs/2026-08-27-toast点击卡片无法抢焦点因inline-plugin命令未授权capability.md
   - .agent/bugs/2026-08-27-toast小窗增高时卡片闪到任务栏.md
   - .agent/bugs/2026-08-11-toast-全屏覆盖层空白区域无法点击穿透.md

--- a/src-tauri/src/plugin_sidecar.rs
+++ b/src-tauri/src/plugin_sidecar.rs
@@ -126,12 +126,6 @@ impl PluginSidecarManager {
         self.sync_impl(app, plugins, false)
     }
 
-    /// Synchronous variant used by enable/disable toggle so the response can
-    /// report fresh `sidecar_running`. Restarts every running sidecar.
-    pub fn sync_force(&self, app: &tauri::AppHandle, plugins: &PluginManager) -> Result<(), String> {
-        self.sync_impl(app, plugins, true)
-    }
-
     fn sync_impl(
         &self,
         app: &tauri::AppHandle,

--- a/src-tauri/src/plugin_sidecar.rs
+++ b/src-tauri/src/plugin_sidecar.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -20,7 +20,6 @@ struct PendingRequest {
 }
 
 struct RunningSidecar {
-    fingerprint: String,
     child: Child,
     stdin: Arc<Mutex<ChildStdin>>,
     #[cfg(windows)]
@@ -107,8 +106,8 @@ impl PluginSidecarManager {
         self.schedule_sync_impl(app, plugins, false);
     }
 
-    /// Same as `schedule_sync`, but restarts every running sidecar (not just
-    /// crashed/fingerprint-changed ones). Used by the explicit reload/refresh.
+    /// Same as `schedule_sync`, but restarts every enabled sidecar.
+    /// Used by the explicit reload/refresh button.
     pub fn schedule_sync_force(&self, app: tauri::AppHandle, plugins: PluginManager) {
         self.schedule_sync_impl(app, plugins, true);
     }
@@ -122,8 +121,30 @@ impl PluginSidecarManager {
         });
     }
 
-    pub fn sync(&self, app: &tauri::AppHandle, plugins: &PluginManager) -> Result<(), String> {
-        self.sync_impl(app, plugins, false)
+    /// Enable/disable one plugin: start it if enabled, stop it if disabled.
+    /// Does not restart a healthy running sidecar. Sibling sidecars stay put.
+    pub fn sync_plugin(
+        &self,
+        app: &tauri::AppHandle,
+        plugins: &PluginManager,
+        plugin_id: &str,
+    ) -> Result<(), String> {
+        let _sync_guard = self.sync_lock.lock().map_err(|e| e.to_string())?;
+        let spec = plugins
+            .sidecar_plugins()?
+            .into_iter()
+            .find(|spec| spec.id == plugin_id);
+        let mut running = self.running.lock().map_err(|e| e.to_string())?;
+        match spec {
+            None => {
+                if let Some(sidecar) = running.remove(plugin_id) {
+                    stop_sidecar(plugin_id, sidecar);
+                    self.fail_pending_for_plugin(plugin_id, "plugin sidecar stopped");
+                }
+                Ok(())
+            }
+            Some(spec) => self.replace_sidecar_if_needed(app, plugins, &mut running, &spec, false),
+        }
     }
 
     fn sync_impl(
@@ -134,14 +155,11 @@ impl PluginSidecarManager {
     ) -> Result<(), String> {
         let _sync_guard = self.sync_lock.lock().map_err(|e| e.to_string())?;
         let desired = plugins.sidecar_plugins()?;
-        let desired_map: HashMap<_, _> = desired
-            .iter()
-            .map(|spec| (spec.id.clone(), spec.fingerprint.clone()))
-            .collect();
+        let desired_ids: HashSet<_> = desired.iter().map(|spec| spec.id.clone()).collect();
         let mut running = self.running.lock().map_err(|e| e.to_string())?;
         let stopped: Vec<String> = running
             .keys()
-            .filter(|id| !desired_map.contains_key(*id))
+            .filter(|id| !desired_ids.contains(*id))
             .cloned()
             .collect();
         for id in stopped {
@@ -151,42 +169,50 @@ impl PluginSidecarManager {
             }
         }
         for spec in desired {
-            let restart = if force {
-                true
-            } else {
-                match running.get_mut(&spec.id) {
-                    Some(sidecar) => {
-                        sidecar
-                            .child
-                            .try_wait()
-                            .map_err(|e| format!("check plugin sidecar {} status: {e}", spec.id))?
-                            .is_some()
-                            || sidecar.fingerprint != spec.fingerprint
-                    }
-                    None => true,
-                }
-            };
-            if !restart {
-                continue;
-            }
-            if let Some(sidecar) = running.remove(&spec.id) {
-                stop_sidecar(&spec.id, sidecar);
-                self.fail_pending_for_plugin(&spec.id, "plugin sidecar restarted");
-            }
-            let id = spec.id.clone();
-            let spawned = spawn_sidecar(app, plugins, &spec, self.clone())?;
-            running.insert(
-                id.clone(),
-                RunningSidecar {
-                    fingerprint: spec.fingerprint.clone(),
-                    child: spawned.child,
-                    stdin: spawned.stdin,
-                    #[cfg(windows)]
-                    job: spawned.job,
-                },
-            );
-            log_info!("plugin-sidecar", "started sidecar for {id}");
+            self.replace_sidecar_if_needed(app, plugins, &mut running, &spec, force)?;
         }
+        Ok(())
+    }
+
+    fn replace_sidecar_if_needed(
+        &self,
+        app: &tauri::AppHandle,
+        plugins: &PluginManager,
+        running: &mut HashMap<String, RunningSidecar>,
+        spec: &PluginSidecarSpec,
+        force: bool,
+    ) -> Result<(), String> {
+        let restart = if force {
+            true
+        } else {
+            match running.get_mut(&spec.id) {
+                Some(sidecar) => sidecar
+                    .child
+                    .try_wait()
+                    .map_err(|e| format!("check plugin sidecar {} status: {e}", spec.id))?
+                    .is_some(),
+                None => true,
+            }
+        };
+        if !restart {
+            return Ok(());
+        }
+        if let Some(sidecar) = running.remove(&spec.id) {
+            stop_sidecar(&spec.id, sidecar);
+            self.fail_pending_for_plugin(&spec.id, "plugin sidecar restarted");
+        }
+        let id = spec.id.clone();
+        let spawned = spawn_sidecar(app, plugins, spec, self.clone())?;
+        running.insert(
+            id.clone(),
+            RunningSidecar {
+                child: spawned.child,
+                stdin: spawned.stdin,
+                #[cfg(windows)]
+                job: spawned.job,
+            },
+        );
+        log_info!("plugin-sidecar", "started sidecar for {id}");
         Ok(())
     }
 

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -124,6 +124,9 @@ pub struct PluginSidecarSpec {
     pub args: Vec<String>,
     pub cwd: PathBuf,
     pub env: HashMap<String, String>,
+    /// Recorded for diagnostics / tests. Restart policy is enable/disable +
+    /// the reload button, not fingerprint mismatch.
+    #[allow(dead_code)]
     pub fingerprint: String,
 }
 
@@ -720,8 +723,8 @@ pub fn list_external_plugins(
     }
 
     windows.schedule_sync(app.clone(), mgr.inner().clone());
-    // Explicit reload/refresh restarts sidecars so on-disk changes take effect;
-    // passive rescans (startup, toast init) keep the diff-based sync.
+    // Reload button: restart every enabled sidecar. Other list/rescans only
+    // start missing / stop disabled / replace crashed — never bounce healthy ones.
     if restart_sidecars.unwrap_or(false) {
         sidecars.schedule_sync_force(app.clone(), mgr.inner().clone());
     } else {
@@ -741,11 +744,9 @@ pub fn set_external_plugin_enabled(
 ) -> Result<ExternalPluginInfo, String> {
     let mut info = mgr.set_enabled(&app, &id, enabled)?;
     windows.schedule_sync(app.clone(), mgr.inner().clone());
-    // Sync sidecar lifecycle before reporting runtime status so the UI
-    // does not lag one refresh behind enable/disable. Diff-based: only the
-    // toggled plugin's sidecar starts/stops; fingerprint covers manifest and
-    // entry files, so script edits still take effect on the next toggle.
-    if let Err(e) = sidecars.inner().sync(&app, mgr.inner()) {
+    // Enable starts this sidecar; disable stops it. Script edits take effect
+    // on the reload button, not by flipping the switch.
+    if let Err(e) = sidecars.inner().sync_plugin(&app, mgr.inner(), &id) {
         log_warn!("plugins", "sidecar sync after enable toggle failed: {e}");
     }
     if info.has_sidecar {

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -571,8 +571,25 @@ fn sidecar_fingerprint(
 ) -> String {
     let mut env_pairs: Vec<_> = env.iter().collect();
     env_pairs.sort_by(|a, b| a.0.cmp(b.0));
+    // Entry-file stats (len:mtime_ms, in args order) so script edits change the
+    // fingerprint like the background entry does (ADR sidecar-runtime #6).
+    let entry_stats: Vec<String> = args
+        .iter()
+        .filter(|a| !a.starts_with('-') && !a.contains("..") && !Path::new(a).is_absolute())
+        .filter_map(|a| fs::metadata(cwd.join(a)).ok())
+        .map(|meta| {
+            let len = meta.len();
+            let modified = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis())
+                .unwrap_or_default();
+            format!("{len}:{modified}")
+        })
+        .collect();
     format!(
-        "{version}:{command}:{args:?}:{}:{env_pairs:?}",
+        "{version}:{command}:{args:?}:{}:{env_pairs:?}:{entry_stats:?}",
         cwd.display()
     )
 }
@@ -642,7 +659,7 @@ fn event_allowed(events: &[String], kind: &str, event_type: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{sidecar_spec, PluginSidecarManifest};
+    use super::{sidecar_fingerprint, sidecar_spec, PluginSidecarManifest};
     use std::collections::HashMap;
     use std::path::Path;
 
@@ -664,6 +681,22 @@ mod tests {
         assert_eq!(spec.args, manifest.args);
         assert_eq!(spec.cwd, Path::new("/plugins/demo").join("../runtime"));
         assert_eq!(spec.env, manifest.env);
+    }
+
+    #[test]
+    fn sidecar_fingerprint_tracks_entry_file_changes() {
+        let dir = std::env::temp_dir().join(format!("catrace-fp-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let entry = dir.join("main.mjs");
+        std::fs::write(&entry, "console.log(1)").unwrap();
+        let fp1 = sidecar_fingerprint("1", "node", &["main.mjs".into()], &dir, &HashMap::new());
+        std::fs::write(&entry, "console.log(1); console.log(2)").unwrap();
+        let fp2 = sidecar_fingerprint("1", "node", &["main.mjs".into()], &dir, &HashMap::new());
+        let fp3 = sidecar_fingerprint("1", "node", &["main.mjs".into()], &dir, &HashMap::new());
+        assert_ne!(fp1, fp2, "entry file edit must change the sidecar fingerprint");
+        assert_eq!(fp2, fp3, "identical state must produce an identical fingerprint");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 
@@ -709,9 +742,10 @@ pub fn set_external_plugin_enabled(
     let mut info = mgr.set_enabled(&app, &id, enabled)?;
     windows.schedule_sync(app.clone(), mgr.inner().clone());
     // Sync sidecar lifecycle before reporting runtime status so the UI
-    // does not lag one refresh behind enable/disable. Force: restart every
-    // enabled sidecar so on-disk/manifest changes never leave stale state.
-    if let Err(e) = sidecars.inner().sync_force(&app, mgr.inner()) {
+    // does not lag one refresh behind enable/disable. Diff-based: only the
+    // toggled plugin's sidecar starts/stops; fingerprint covers manifest and
+    // entry files, so script edits still take effect on the next toggle.
+    if let Err(e) = sidecars.inner().sync(&app, mgr.inner()) {
         log_warn!("plugins", "sidecar sync after enable toggle failed: {e}");
     }
     if info.has_sidecar {


### PR DESCRIPTION
96da4e1 为让「改 runtime 脚本后刷新生效」把 enable/disable 改为 force 全量重启 所有已启用 sidecar,导致开关任意外部插件都会把其他插件的进程树
(taskkill /T /F + Job Object kill-on-close)连带杀掉,如 bt-music 的播放器 exe。

- sidecar_fingerprint 补 entry 脚本文件 len:mtime_ms,对齐 ADR sidecar-runtime #6
- set_external_plugin_enabled 改回 diff 式 sync:只启停被开关的插件
- 删除失去调用的 sync_force;刷新按钮 schedule_sync_force 保留
- 新增单测 sidecar_fingerprint_tracks_entry_file_changes