### PR TITLE
fix(toast): Windows 文本大小导致卡片被裁切

### DIFF
--- a/.agent/features/toast-window/README.md
+++ b/.agent/features/toast-window/README.md
@@ -60,7 +60,7 @@ Toast 默认是 `WS_EX_NOACTIVATE` 无焦点窗，鼠标滑入/选择文本不�
 
 ## 定位职责
 
-- Rust `fit_toast_window` 按光标屏 `work_area` 把小窗钉在右下；物理像素一次写入（切屏 DPI 仍走 `set_window_rect_physical`）
+- Rust `fit_toast_window` 按光标屏 `work_area` 把小窗钉在右下；物理像素一次写入（切屏 DPI 仍走 `set_window_rect_physical`）。Windows 还需乘辅助功能「文本大小」系数，否则 WebView 视觉放大后卡片会被裁切。
 - 前端 `setToastContentSize` 上报内容逻辑宽高；高度随卡片变化，Rust clamp 到 work_area
 - 已可见时连点只堆叠，不反复 show / 不跟光标跳屏
 - 依赖窗口/显示器相关 core 权限（如 `core:window:allow-current-monitor`、`core:window:allow-scale-factor` 等，见 `src-tauri/capabilities/default.json`）

--- a/.agent/features/toast-window/toast小窗化实现-右下角定位-内容尺寸上报-与去穿透.md
+++ b/.agent/features/toast-window/toast小窗化实现-右下角定位-内容尺寸上报-与去穿透.md
@@ -35,8 +35,9 @@ fn fit_toast_window(window, app_handle, follow_cursor) {
     let scale = monitor.scale_factor();
     let content = toast_content_size();
 
-    let width = (content.width * scale).round().clamp(1, area.width);
-    let height = (content.height * scale).round().clamp(1, area.height);
+    let text_scale = os_text_scale_factor(); // Windows 文本大小，其它平台 1.0
+    let width = (content.width * scale * text_scale).round().clamp(1, area.width);
+    let height = (content.height * scale * text_scale).round().clamp(1, area.height);
     let x = area.position.x + area.width - width;
     let y = area.position.y + area.height - height;
 
@@ -47,6 +48,7 @@ fn fit_toast_window(window, app_handle, follow_cursor) {
 - `follow_cursor=true`：按光标选屏（首次显示、测试触发）
 - `follow_cursor=false`：按窗口当前所在屏选屏（内容高度变化、DPI 变化）
 - 使用 `set_window_rect_physical` 一次写入物理像素，避免 tao 分步 set_size/set_position 的 DPI 竞态
+- **Windows「文本大小」**（设置 → 辅助功能 → 文本大小，注册表 `TextScaleFactor`）会让 WebView2 把页面视觉放大，但 CSS `scrollHeight` 仍按 16px rem 上报。`fit_toast_window` 必须再乘 `os_text_scale_factor()`，否则卡片底部被 HWND 裁切。显示器缩放（DPI）和文本大小是两件事，不能互相替代。
 
 ### 前端上报内容尺寸
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ zip = "2"
 rodio = "0.20"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.61", features = ["Win32_Graphics_Dwm", "Win32_System_Com", "Win32_Media_Audio", "Win32_Media_Audio_Endpoints", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_System_JobObjects", "Win32_Security", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }
+windows = { version = "0.61", features = ["Win32_Graphics_Dwm", "Win32_System_Com", "Win32_Media_Audio", "Win32_Media_Audio_Endpoints", "Win32_System_Threading", "Win32_System_ProcessStatus", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Diagnostics_Debug", "Win32_System_JobObjects", "Win32_Security", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-accessibility-client = "0.0.1"

--- a/src-tauri/src/reminder_toast.rs
+++ b/src-tauri/src/reminder_toast.rs
@@ -18,6 +18,15 @@ const TOAST_WINDOW_WIDTH_LOGICAL: f64 = 392.0;
 /// 逻辑像素：单卡约 128 + 上下出血 16×2。
 const TOAST_WINDOW_MIN_HEIGHT_LOGICAL: f64 = 160.0;
 
+/// CSS 逻辑尺寸 → 物理像素。`text_scale` 是 Windows「文本大小」（默认 1.0）。
+fn physical_content_px(logical: f64, dpi_scale: f64, text_scale: f64, max: u32) -> u32 {
+    let scaled = logical * dpi_scale * text_scale;
+    if !scaled.is_finite() || scaled <= 0.0 {
+        return 1;
+    }
+    (scaled.round() as u32).clamp(1, max.max(1))
+}
+
 /// 全局异步锁，串行化所有 Toast 窗口的创建/显示/追加操作。
 /// 防止快速连续触发时并发操作 WebviewWindow 导致崩溃。
 static TOAST_MUTEX: Mutex<()> = Mutex::const_new(());
@@ -165,19 +174,21 @@ fn fit_toast_window(
 
     let max_w = area.size.width.max(1);
     let max_h = area.size.height.max(1);
-    let width = ((content.width * scale).round() as u32).clamp(1, max_w);
-    let height = ((content.height * scale).round() as u32).clamp(1, max_h);
+    let text_scale = window_manager::os_text_scale_factor();
+    let width = physical_content_px(content.width, scale, text_scale, max_w);
+    let height = physical_content_px(content.height, scale, text_scale, max_h);
     let x = area.position.x + area.size.width as i32 - width as i32;
     let y = area.position.y + area.size.height as i32 - height as i32;
 
     log_info!(
         "toast-win",
-        "fit: work_area=({},{},{}x{}) scale={} content_logical={}x{} physical=({},{},{}x{}) follow_cursor={}",
+        "fit: work_area=({},{},{}x{}) scale={} text_scale={} content_logical={}x{} physical=({},{},{}x{}) follow_cursor={}",
         area.position.x,
         area.position.y,
         area.size.width,
         area.size.height,
         scale,
+        text_scale,
         content.width,
         content.height,
         x,
@@ -646,5 +657,28 @@ pub fn create_update_toast_window(
 
     if !try_publish_toast_event(app_handle, bus_event) {
         ensure_toast_window_visible(app_handle);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::physical_content_px;
+
+    #[test]
+    fn physical_size_matches_dpi_only_when_text_scale_is_default() {
+        assert_eq!(physical_content_px(392.0, 1.5, 1.0, 2560), 588);
+        assert_eq!(physical_content_px(339.0, 1.5, 1.0, 1528), 509);
+    }
+
+    #[test]
+    fn physical_size_grows_with_windows_text_scale() {
+        // 150% DPI + 125% 文本大小：339 * 1.5 * 1.25 = 635.625 → 636
+        assert_eq!(physical_content_px(339.0, 1.5, 1.25, 1528), 636);
+        assert_eq!(physical_content_px(392.0, 1.5, 1.25, 2560), 735);
+    }
+
+    #[test]
+    fn physical_size_clamps_to_work_area() {
+        assert_eq!(physical_content_px(2000.0, 1.5, 2.25, 1528), 1528);
     }
 }

--- a/src-tauri/src/window_manager/macos.rs
+++ b/src-tauri/src/window_manager/macos.rs
@@ -31,6 +31,11 @@ pub fn show_reminder_no_activate(_app_handle: &tauri::AppHandle, window: &tauri:
     });
 }
 
+/// Windows「文本大小」无对应项时按 1.0。
+pub fn os_text_scale_factor() -> f64 {
+    1.0
+}
+
 /// 非 Windows：仍走 Tauri PhysicalSize/PhysicalPosition。
 pub fn set_window_rect_physical(
     window: &tauri::WebviewWindow,

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -20,8 +20,8 @@ pub async fn set_window_active_mode<R: Runtime>(window: WebviewWindow<R>, active
 }
 
 pub use platform::{
-    hide_window_internal, set_window_active_mode_internal, set_window_rect_physical,
-    show_reminder_no_activate,
+    hide_window_internal, os_text_scale_factor, set_window_active_mode_internal,
+    set_window_rect_physical, show_reminder_no_activate,
 };
 
 /// 初始化窗口管理插件

--- a/src-tauri/src/window_manager/windows.rs
+++ b/src-tauri/src/window_manager/windows.rs
@@ -12,6 +12,36 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use crate::{log_info, log_warn};
 use super::shared::{is_reminder_window, shared_hide_window, shared_show_window};
 
+/// Windows 设置 → 辅助功能 → 文本大小。WebView2 会把页面视觉放大，但不改 CSS 布局；
+/// Toast 小窗必须按这个系数放大 HWND，否则卡片底部会被裁切。
+/// 注册表 `HKCU\Software\Microsoft\Accessibility\TextScaleFactor`，100–225。
+pub fn os_text_scale_factor() -> f64 {
+    use windows::core::w;
+    use windows::Win32::Foundation::ERROR_SUCCESS;
+    use windows::Win32::System::Registry::{
+        HKEY_CURRENT_USER, REG_VALUE_TYPE, RRF_RT_REG_DWORD, RegGetValueW,
+    };
+
+    let mut data: u32 = 100;
+    let mut size = std::mem::size_of::<u32>() as u32;
+    let mut value_type = REG_VALUE_TYPE(0);
+    let err = unsafe {
+        RegGetValueW(
+            HKEY_CURRENT_USER,
+            w!("Software\\Microsoft\\Accessibility"),
+            w!("TextScaleFactor"),
+            RRF_RT_REG_DWORD,
+            Some(&mut value_type),
+            Some((&mut data as *mut u32).cast()),
+            Some(&mut size),
+        )
+    };
+    if err != ERROR_SUCCESS || data < 100 {
+        return 1.0;
+    }
+    (data.min(225) as f64) / 100.0
+}
+
 fn window_hwnd(window: &WebviewWindow<tauri::Wry>) -> Option<HWND> {
     window.hwnd().ok().map(|h| HWND(h.0 as *mut _))
 }

--- a/src/views/toastWindows/ReminderToast.vue
+++ b/src/views/toastWindows/ReminderToast.vue
@@ -332,6 +332,13 @@ async function reportWindowSize() {
   const width = Math.max(1, Math.ceil(root.scrollWidth))
   const height = Math.max(160, Math.ceil(stack.scrollHeight))
   const key = `${width}x${height}`
+
+  // 卡片离场/进入动画期间禁止收缩窗口，避免 DOM 里卡片还没移除但窗口先变小导致截断
+  if (isAnimating.value) {
+    const prevH = Number.parseFloat(lastSizeKey.split('x')[1] || '0')
+    if (height <= prevH) return
+  }
+
   if (key === lastSizeKey) return
   lastSizeKey = key
   try {


### PR DESCRIPTION
WebView2 会按辅助功能「文本大小」放大画面，但 CSS 尺寸仍按 16px rem 上报。
fit 时乘 TextScaleFactor 放大 HWND；离场动画期间禁止收缩窗口，避免底部卡片截断。